### PR TITLE
Set working directory as sink path

### DIFF
--- a/src/Service/SnapshotDownloadService.php
+++ b/src/Service/SnapshotDownloadService.php
@@ -47,7 +47,7 @@ class SnapshotDownloadService
         $progressBar->setFormat('[%bar%] %percent%%');
 
         $this->client->get($downloadLink, [
-            RequestOptions::SINK => $filename,
+            RequestOptions::SINK => getcwd() . DIRECTORY_SEPARATOR . $filename,
             RequestOptions::PROGRESS => function ($dl_total_size, $dl_size_so_far) use ($progressBar, $totalSize) {
                 $progress = round(($dl_size_so_far / $totalSize) * 100);
                 $progressBar->setProgress($progress);


### PR DESCRIPTION
Using just the filename was failing when this code was bundled into a
PHAR.